### PR TITLE
ESP platform (ESP32 and likely 8266) fixes

### DIFF
--- a/DS1340lib.cpp
+++ b/DS1340lib.cpp
@@ -2,7 +2,9 @@
 // Released to the public domain! Enjoy!
 
 #include <Wire.h>
-#include <avr/pgmspace.h>
+#if !defined(ESP_PLATFORM)
+  #include <avr/pgmspace.h>
+#endif
 #include "DS1340lib.h"
 #include <Arduino.h>
 
@@ -152,37 +154,41 @@ void RTC_DS1340::adjust(const DateTime& dt) {
     Wire.endTransmission();
 }
 
-DateTime RTC_DS1340::enabletricklecharger() {
+uint8_t RTC_DS1340::enabletricklecharger() {
   Wire.beginTransmission(DS1340_ADDRESS);
   Wire.write(8);	
   Wire.write(0xA6); // No diode, 2k resistor (Don't use 250 ohm on arduino. It will burn the resistor with VCC above 3.63V)
-  Wire.endTransmission();
+  return Wire.endTransmission();
 }
 
-DateTime RTC_DS1340::disabletricklecharger() {
+uint8_t RTC_DS1340::disabletricklecharger() {
   Wire.beginTransmission(DS1340_ADDRESS);
   Wire.write(8);	
   Wire.write(0x00); // No charge at all
-  Wire.endTransmission();
+  return Wire.endTransmission();
 }
 
-DateTime RTC_DS1340::enableFTout() {
+uint8_t RTC_DS1340::enableFTout() {
+  uint8_t status;
   Wire.beginTransmission(DS1340_ADDRESS);
   Wire.write(7);	
-  Wire.endTransmission();
+  status = Wire.endTransmission();
+  if (status != 0) { return status; }
   
   Wire.requestFrom(DS1340_ADDRESS, 1);
   uint8_t setreg = Wire.read() | 0xC0; // Read from address 7 and set OUT and FT high
   Wire.beginTransmission(DS1340_ADDRESS);
   Wire.write(7);	
   Wire.write(setreg);                      // Put the values back where they came from
-  Wire.endTransmission();
+  return Wire.endTransmission();
 }
 
-DateTime RTC_DS1340::disableFTout() {
+uint8_t RTC_DS1340::disableFTout() {
+  uint8_t status;
   Wire.beginTransmission(DS1340_ADDRESS);
   Wire.write(7);	
-  Wire.endTransmission();
+  status = Wire.endTransmission();
+  if (status != 0) { return status; }
   
   Wire.requestFrom(DS1340_ADDRESS, 1);
   uint8_t setreg = Wire.read() & 0xBF; // Read from address 7 and set FT low

--- a/DS1340lib.h
+++ b/DS1340lib.h
@@ -32,10 +32,10 @@ public:
     static void adjust(const DateTime& dt);
     uint8_t isrunning(void);
     static DateTime now();
-    static DateTime enabletricklecharger(void);
-    static DateTime disabletricklecharger(void);
-    static DateTime enableFTout(void);
-    static DateTime disableFTout(void);
+    static uint8_t enabletricklecharger(void);
+    static uint8_t disabletricklecharger(void);
+    static uint8_t enableFTout(void);
+    static uint8_t disableFTout(void);
 };
 
 // RTC using the internal millis() clock, has to be initialized before use


### PR DESCRIPTION
* Selectively disables including avr/pgmspace.h if compiling on ESP platforms
* Change return type of trickle charger and ft-out functions to Wire request status code
* _Actually_ return something in those functions - was causing a nasty infinite transmit loop bug by not having a `return` stanza!

Confirmed working in PlatformIO using Espressif32, highly likely fixes for others too.